### PR TITLE
fix: center landing page sections

### DIFF
--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -115,12 +115,12 @@ export default function LandingPage({ onSelect }: Props) {
         {/* Warrior Section */}
         <section
           onClick={() => onSelect('warrior')}
-          className="group relative flex-1 cursor-pointer overflow-hidden border-r-2 border-[#8b4513] bg-gradient-to-br from-[#2c1810] via-[#4a2c1a] to-[#1a1611] text-[#d4953a] transition-all duration-500 hover:flex-[1.2]"
+          className="group relative flex flex-1 cursor-pointer items-center justify-center overflow-hidden border-r-2 border-[#8b4513] bg-gradient-to-br from-[#2c1810] via-[#4a2c1a] to-[#1a1611] text-[#d4953a] transition-all duration-500 hover:flex-[1.2]"
         >
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="title-background text-[8rem] font-black tracking-widest opacity-10">WARRIOR</div>
           </div>
-          <div className="section-content relative z-10 mx-auto max-w-xs text-center">
+          <div className="section-content relative z-10 mx-auto flex max-w-xs flex-col items-center text-center">
             <div className="relative mb-6 flex flex-col items-center">
               <div className="absolute -top-12">
                 <VikingWarriorIcon />
@@ -165,12 +165,12 @@ export default function LandingPage({ onSelect }: Props) {
         {/* Skald Section */}
         <section
           onClick={() => onSelect('skald')}
-          className="group relative flex-1 cursor-pointer overflow-hidden border-l-2 border-[#4682b4] bg-gradient-to-br from-[#1a2332] via-[#2d4a6b] to-[#1a1611] text-[#87ceeb] transition-all duration-500 hover:flex-[1.2]"
+          className="group relative flex flex-1 cursor-pointer items-center justify-center overflow-hidden border-l-2 border-[#4682b4] bg-gradient-to-br from-[#1a2332] via-[#2d4a6b] to-[#1a1611] text-[#87ceeb] transition-all duration-500 hover:flex-[1.2]"
         >
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="title-background text-[8rem] font-black tracking-widest opacity-10">SKALD</div>
           </div>
-          <div className="section-content relative z-10 mx-auto max-w-xs text-center">
+          <div className="section-content relative z-10 mx-auto flex max-w-xs flex-col items-center text-center">
             <div className="relative mb-6 flex flex-col items-center">
               <div className="absolute -top-12">
                 <VikingSkaldIcon />


### PR DESCRIPTION
## Summary
- center-align Warrior and Skald sections on the landing page using flex utilities

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689921c3e9b0832abb211972a50bb41c