### PR TITLE
Fix homepage crest alignment and font weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+package-lock.json
+

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=JetBrains+Mono&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=JetBrains+Mono:wght@400;700&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -152,15 +152,9 @@ export default function LandingPage({ onSelect }: Props) {
             </div>
           </div>
         </section>
-
+        
         {/* Central Divider */}
-        <div className="central-divider relative w-1 bg-gradient-to-b from-[#d4953a] via-[#8b4513] to-[#4682b4]">
-          <div className="viking-crest absolute left-1/2 top-1/2 flex h-20 w-20 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-4 border-[#8b4513] bg-black/60">
-            <div className="shield-ring ring-outer absolute inset-0 rounded-full border-2 border-[#d4953a]/60 animate-spin-slow" />
-            <div className="shield-ring ring-inner absolute inset-1.5 rounded-full border-2 border-[#d4953a]/60 animate-spin-slower" />
-            <div className="text-2xl font-bold text-[#d4953a]">⚡</div>
-          </div>
-        </div>
+        <div className="central-divider w-1 bg-gradient-to-b from-[#d4953a] via-[#8b4513] to-[#4682b4]" />
 
         {/* Skald Section */}
         <section
@@ -202,6 +196,13 @@ export default function LandingPage({ onSelect }: Props) {
             </div>
           </div>
         </section>
+      </div>
+
+      {/* Viking Crest */}
+      <div className="viking-crest pointer-events-none absolute left-1/2 top-1/2 z-10 flex h-20 w-20 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-4 border-[#8b4513] bg-black/60">
+        <div className="shield-ring ring-outer absolute inset-0 rounded-full border-2 border-[#d4953a]/60 animate-spin-slow" />
+        <div className="shield-ring ring-inner absolute inset-1.5 rounded-full border-2 border-[#d4953a]/60 animate-spin-slower" />
+        <div className="text-2xl font-bold text-[#d4953a]">⚡</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- center viking crest over divider with absolute positioning
- load Cinzel and JetBrains Mono with proper weights
- add gitignore for node_modules

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689924d70434832a802ee37c3fe83b5b