### PR TITLE
Enhance mobile responsiveness

### DIFF
--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -14,8 +14,7 @@ const skaldRunes = ['Epic Tales', 'Verses', 'Chronicles', 'Legends', 'Ballads'];
 const VikingWarriorIcon = () => (
   <svg
     viewBox="0 0 32 32"
-    width="120"
-    height="120"
+    className="w-24 h-24 md:w-32 md:h-32"
     style={{ imageRendering: 'pixelated', display: 'block' }}
   >
     <rect x="0" y="0" width="32" height="32" fill="transparent" />
@@ -48,8 +47,7 @@ const VikingWarriorIcon = () => (
 const VikingSkaldIcon = () => (
   <svg
     viewBox="0 0 32 32"
-    width="120"
-    height="120"
+    className="w-24 h-24 md:w-32 md:h-32"
     style={{ imageRendering: 'pixelated', display: 'block' }}
   >
     <rect x="0" y="0" width="32" height="32" fill="transparent" />
@@ -111,42 +109,42 @@ export default function LandingPage({ onSelect }: Props) {
         />
       </div>
 
-      <div className="landing-page flex h-screen">
+      <div className="landing-page flex h-screen flex-col md:flex-row">
         {/* Warrior Section */}
         <section
           onClick={() => onSelect('warrior')}
-          className="group relative flex flex-1 cursor-pointer items-center justify-center overflow-hidden border-r-2 border-[#8b4513] bg-gradient-to-br from-[#2c1810] via-[#4a2c1a] to-[#1a1611] text-[#d4953a] transition-all duration-500 hover:flex-[1.2]"
+          className="group relative flex flex-1 cursor-pointer items-center justify-center overflow-hidden border-b-2 border-[#8b4513] bg-gradient-to-br from-[#2c1810] via-[#4a2c1a] to-[#1a1611] text-[#d4953a] transition-all duration-500 hover:flex-[1.2] md:border-b-0 md:border-r-2"
         >
           <div className="absolute inset-0 flex items-center justify-center">
-            <div className="title-background text-[8rem] font-black tracking-widest opacity-10">WARRIOR</div>
+            <div className="title-background text-[4rem] sm:text-[6rem] md:text-[8rem] font-black tracking-widest opacity-10">WARRIOR</div>
           </div>
           <div className="section-content relative z-10 mx-auto flex max-w-xs flex-col items-center text-center">
             <div className="relative mb-6 flex flex-col items-center">
-              <div className="absolute -top-12">
+              <div className="absolute top-0 left-1/2 -translate-x-1/2 md:-top-12">
                 <VikingWarriorIcon />
               </div>
-              <span className="title-main block pt-24 text-3xl font-bold tracking-widest">WARRIOR</span>
+              <span className="title-main block pt-28 md:pt-24 text-2xl font-bold tracking-widest md:text-3xl">WARRIOR</span>
               <span
                 key={warriorIndex}
-                className="title-sub block text-lg italic opacity-80 transition-opacity duration-300"
+                className="title-sub block text-base italic opacity-80 transition-opacity duration-300 md:text-lg"
               >
                 {warriorTexts[warriorIndex]}
               </span>
             </div>
-            <p className="section-description mb-6 font-mono text-sm opacity-90">
+            <p className="section-description mb-6 font-mono text-xs opacity-90 sm:text-sm">
               Wielding modern weapons to conquer digital realms. Building fortresses that stand the test of time.
             </p>
             <div className="skill-runes mb-8 flex flex-wrap justify-center gap-2">
               {warriorRunes.map(r => (
                 <span
                   key={r}
-                  className="rune-tag rounded border border-current bg-black/30 px-2 py-1 text-sm font-mono"
+                  className="rune-tag rounded border border-current bg-black/30 px-2 py-1 text-xs font-mono sm:text-sm"
                 >
                   {r}
                 </span>
               ))}
             </div>
-            <div className="action-hint flex items-center justify-center gap-2 text-sm opacity-70 font-mono">
+            <div className="action-hint flex items-center justify-center gap-2 text-xs font-mono opacity-70 sm:text-sm">
               <span>Enter the workshop</span>
               <span className="axe-indicator animate-axe">⚔️</span>
             </div>
@@ -154,9 +152,9 @@ export default function LandingPage({ onSelect }: Props) {
         </section>
         
         {/* Central Divider */}
-        <div className="central-divider relative w-1 bg-gradient-to-b from-[#d4953a] via-[#8b4513] to-[#4682b4]">
+        <div className="central-divider relative h-1 w-full bg-gradient-to-r from-[#d4953a] via-[#8b4513] to-[#4682b4] md:h-full md:w-1 md:bg-gradient-to-b">
           {/* Viking Crest */}
-          <div className="viking-crest pointer-events-none absolute left-1/2 top-1/2 z-10 flex h-20 w-20 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-4 border-[#8b4513] bg-black/60">
+          <div className="viking-crest pointer-events-none absolute left-1/2 top-1/2 z-10 flex h-16 w-16 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-4 border-[#8b4513] bg-black/60 md:h-20 md:w-20">
             <div className="shield-ring ring-outer absolute inset-0 rounded-full border-2 border-[#d4953a]/60 animate-spin-slow" />
             <div className="shield-ring ring-inner absolute inset-1.5 rounded-full border-2 border-[#d4953a]/60 animate-spin-slower" />
             <div className="text-2xl font-bold text-[#d4953a]">⚡</div>
@@ -166,38 +164,38 @@ export default function LandingPage({ onSelect }: Props) {
         {/* Skald Section */}
         <section
           onClick={() => onSelect('skald')}
-          className="group relative flex flex-1 cursor-pointer items-center justify-center overflow-hidden border-l-2 border-[#4682b4] bg-gradient-to-br from-[#1a2332] via-[#2d4a6b] to-[#1a1611] text-[#87ceeb] transition-all duration-500 hover:flex-[1.2]"
+          className="group relative flex flex-1 cursor-pointer items-center justify-center overflow-hidden border-t-2 border-[#4682b4] bg-gradient-to-br from-[#1a2332] via-[#2d4a6b] to-[#1a1611] text-[#87ceeb] transition-all duration-500 hover:flex-[1.2] md:border-t-0 md:border-l-2"
         >
           <div className="absolute inset-0 flex items-center justify-center">
-            <div className="title-background text-[8rem] font-black tracking-widest opacity-10">SKALD</div>
+            <div className="title-background text-[4rem] sm:text-[6rem] md:text-[8rem] font-black tracking-widest opacity-10">SKALD</div>
           </div>
           <div className="section-content relative z-10 mx-auto flex max-w-xs flex-col items-center text-center">
             <div className="relative mb-6 flex flex-col items-center">
-              <div className="absolute -top-12">
+              <div className="absolute top-0 left-1/2 -translate-x-1/2 md:-top-12">
                 <VikingSkaldIcon />
               </div>
-              <span className="title-main block pt-24 text-3xl font-bold tracking-widest">SKALD</span>
+              <span className="title-main block pt-28 md:pt-24 text-2xl font-bold tracking-widest md:text-3xl">SKALD</span>
               <span
                 key={skaldIndex}
-                className="title-sub block text-lg italic opacity-80 transition-opacity duration-300"
+                className="title-sub block text-base italic opacity-80 transition-opacity duration-300 md:text-lg"
               >
                 {skaldTexts[skaldIndex]}
               </span>
             </div>
-            <p className="section-description mb-6 font-mono text-sm opacity-90">
+            <p className="section-description mb-6 font-mono text-xs opacity-90 sm:text-sm">
               Crafting sagas that echo through the ages. Words that kindle fire in mortal hearts.
             </p>
             <div className="story-runes mb-8 flex flex-wrap justify-center gap-2">
               {skaldRunes.map(r => (
                 <span
                   key={r}
-                  className="rune-tag rounded border border-current bg-black/30 px-2 py-1 text-sm font-mono"
+                  className="rune-tag rounded border border-current bg-black/30 px-2 py-1 text-xs font-mono sm:text-sm"
                 >
                   {r}
                 </span>
               ))}
             </div>
-            <div className="action-hint flex items-center justify-center gap-2 text-sm opacity-70 font-mono">
+            <div className="action-hint flex items-center justify-center gap-2 text-xs font-mono opacity-70 sm:text-sm">
               <span>Enter the hall</span>
               <span className="axe-indicator animate-axe">📜</span>
             </div>

--- a/src/SkaldPage.tsx
+++ b/src/SkaldPage.tsx
@@ -4,29 +4,29 @@ interface Props {
 
 export default function SkaldPage({ onBack }: Props) {
   return (
-    <div className="min-h-screen bg-[#1a1611] text-[#87ceeb] p-8">
+    <div className="min-h-screen bg-[#1a1611] p-4 text-[#87ceeb] md:p-8">
       <button
         onClick={onBack}
-        className="fixed top-8 left-8 bg-black/80 border-2 border-[#4682b4] px-6 py-3 rounded hover:bg-[#4682b4] hover:text-white transition"
+        className="fixed top-4 left-4 rounded border-2 border-[#4682b4] bg-black/80 px-4 py-2 transition hover:bg-[#4682b4] hover:text-white md:top-8 md:left-8 md:px-6 md:py-3"
       >
         ← Return to Longhouse
       </button>
 
-      <div className="max-w-3xl mx-auto mt-24 text-center space-y-12">
+      <div className="mx-auto mt-20 max-w-3xl space-y-12 text-center md:mt-24">
         <div>
           <h1 className="text-4xl md:text-5xl font-bold mb-2">THE SKALD'S HALL</h1>
           <h2 className="text-xl md:text-2xl opacity-90">Where Stories Take Wing</h2>
         </div>
 
-        <div className="border-2 border-[#4682b4] rounded-lg bg-black/50 p-12">
-          <div className="text-2xl my-8 opacity-50">📜 ✨ 📜</div>
+        <div className="rounded-lg border-2 border-[#4682b4] bg-black/50 p-8 md:p-12">
+          <div className="my-6 text-2xl opacity-50 md:my-8">📜 ✨ 📜</div>
           <h3 className="text-2xl md:text-3xl mb-4">Sagas in the Making...</h3>
           <p className="text-base leading-relaxed opacity-90">
             The scribes prepare their finest vellum and sharpest quills.<br />
             Tales of triumph, wisdom, and wonder<br />
             await their moment to be shared with the world.
           </p>
-          <div className="text-2xl my-8 opacity-50">📜 ✨ 📜</div>
+          <div className="my-6 text-2xl opacity-50 md:my-8">📜 ✨ 📜</div>
         </div>
 
         <p className="text-base opacity-70 font-mono">

--- a/src/WarriorPage.tsx
+++ b/src/WarriorPage.tsx
@@ -98,20 +98,20 @@ const testimonials = [
 
 export default function WarriorPage({ onBack }: Props) {
   return (
-    <div className="min-h-screen bg-[#1a1611] text-[#d4953a] p-8">
+    <div className="min-h-screen bg-[#1a1611] p-4 text-[#d4953a] md:p-8">
       <button
         onClick={onBack}
-        className="fixed top-8 left-8 bg-black/80 border-2 border-[#8b4513] px-6 py-3 rounded hover:bg-[#8b4513] hover:text-white transition"
+        className="fixed top-4 left-4 rounded border-2 border-[#8b4513] bg-black/80 px-4 py-2 transition hover:bg-[#8b4513] hover:text-white md:top-8 md:left-8 md:px-6 md:py-3"
       >
         ← Return to Longhouse
       </button>
 
-      <div className="max-w-5xl mx-auto mt-24 space-y-16">
+      <div className="mx-auto mt-20 max-w-5xl space-y-12 md:mt-24 md:space-y-16">
         {/* Hero Section */}
         <section className="text-center space-y-4">
           <h1 className="text-4xl md:text-5xl font-bold">THE WARRIOR'S FORGE</h1>
           <h2 className="text-xl md:text-2xl opacity-90">Where Code Becomes Legend</h2>
-          <div className="bg-black/30 border-2 border-[#8b4513] rounded-lg p-8 max-w-xl mx-auto">
+          <div className="mx-auto max-w-xl rounded-lg border-2 border-[#8b4513] bg-black/30 p-6 md:p-8">
             <div className="flex items-center gap-2 text-[#10b981] font-mono text-sm justify-center mb-4">
               <span className="w-2 h-2 bg-[#10b981] rounded-full animate-pulse"></span>
               <span>Available for new projects</span>
@@ -165,7 +165,7 @@ export default function WarriorPage({ onBack }: Props) {
             {projects.map((proj) => (
               <div
                 key={proj.name}
-                className="bg-black/50 border border-[#8b4513] rounded-xl p-8 transition transform hover:border-[#d4953a] hover:-translate-y-1"
+                className="transform rounded-xl border border-[#8b4513] bg-black/50 p-6 transition hover:-translate-y-1 hover:border-[#d4953a] md:p-8"
               >
                 <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
                   <div>
@@ -213,7 +213,7 @@ export default function WarriorPage({ onBack }: Props) {
             {testimonials.map((t) => (
               <div
                 key={t.author}
-                className="bg-black/50 border border-[#8b4513] rounded-xl p-8 relative transition hover:border-[#d4953a] hover:-translate-y-1"
+                className="relative rounded-xl border border-[#8b4513] bg-black/50 p-6 transition hover:-translate-y-1 hover:border-[#d4953a] md:p-8"
               >
                 <div className="absolute top-5 left-6 text-5xl font-bold opacity-20 text-[#d4953a]">"</div>
                 <p className="relative text-lg leading-relaxed mb-6 opacity-90 pl-4">{t.quote}</p>
@@ -229,7 +229,7 @@ export default function WarriorPage({ onBack }: Props) {
         {/* Call to Action */}
         <section className="text-center">
           <h3 className="text-3xl mb-4">Let's Work Together</h3>
-          <div className="relative bg-black/30 border-2 border-[#8b4513] rounded-2xl p-16 max-w-2xl mx-auto overflow-hidden">
+          <div className="relative mx-auto max-w-2xl overflow-hidden rounded-2xl border-2 border-[#8b4513] bg-black/30 p-10 md:p-16">
             <div className="absolute inset-0 bg-[radial-gradient(circle,rgba(212,149,58,0.05)_0%,transparent_70%)] pointer-events-none"></div>
             <h4 className="text-4xl font-bold mb-4 relative z-10">
               Ready to build something <span className="text-[#8b4513]">exceptional</span>?


### PR DESCRIPTION
## Summary
- Adjust landing page layout, icons, and typography for smoother mobile viewing.
- Tweak warrior and skald pages with responsive padding and controls.
- Reposition pixel viking icons to render correctly on mobile screens.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68992c6fe2bc832a9a7fc19c1d39af61