### PR TITLE
Polish homepage with Viking styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,11 @@ import SmithPage from './SmithPage';
 
 const SiteOverlay = () => (
   <div className="pointer-events-none fixed inset-0 z-0 flex flex-col items-center justify-center text-center select-none text-white/5">
-    <h1 className="text-5xl md:text-8xl font-black tracking-widest">JONJOE WHITFIELD</h1>
+    <h1 className="text-5xl md:text-8xl font-black tracking-widest">Jonjoe Whitfield</h1>
     <p className="mt-2 text-xs md:text-sm tracking-widest">
-      FORGING CODE • CRAFTING SAGAS • HONING STRENGTH
+      Engineer + Storymaker + Nutrition-driven lifter
     </p>
+    <div className="mt-2 h-px w-32 bg-current opacity-10" />
   </div>
 );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,9 @@ import SkaldPage from './SkaldPage';
 import SmithPage from './SmithPage';
 
 const SiteOverlay = () => (
-  <div className="pointer-events-none fixed inset-0 z-0 flex flex-col items-center justify-center text-center select-none text-white/5">
+  <div className="pointer-events-none fixed inset-0 z-20 flex flex-col items-center justify-center text-center select-none text-white/10">
     <h1 className="text-5xl md:text-8xl font-black tracking-widest">Jonjoe Whitfield</h1>
-    <p className="mt-2 text-xs md:text-sm tracking-widest">
-      Engineer + Storymaker + Nutrition-driven lifter
-    </p>
+    <p className="mt-2 text-xs md:text-sm tracking-widest">Tagline</p>
     <div className="mt-2 h-px w-32 bg-current opacity-10" />
   </div>
 );
@@ -36,7 +34,7 @@ const App = () => {
 
   return (
     <div className="relative">
-      <SiteOverlay />
+      {page === 'landing' && <SiteOverlay />}
       <div className="relative z-10">{content}</div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,10 @@ import SkaldPage from './SkaldPage';
 import SmithPage from './SmithPage';
 
 const SiteOverlay = () => (
-  <div className="pointer-events-none fixed inset-0 z-20 flex flex-col items-center justify-center text-center select-none text-white/10">
-    <h1 className="text-5xl md:text-8xl font-black tracking-widest">Jonjoe Whitfield</h1>
-    <p className="mt-2 text-xs md:text-sm tracking-widest">Tagline</p>
-    <div className="mt-2 h-px w-32 bg-current opacity-10" />
+  <div className="pointer-events-none fixed inset-0 z-20 flex flex-col items-center justify-center text-center select-none">
+    <h1 className="text-5xl md:text-8xl font-black tracking-widest text-white/10">Jonjoe Whitfield</h1>
+    <p className="mt-2 text-xs md:text-sm tracking-widest text-white/10">Tagline</p>
+    <div className="mt-2 h-px w-32 bg-white/10" />
   </div>
 );
 

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -146,9 +146,6 @@ export default function LandingPage({ onSelect }: Props) {
           onClick={() => onSelect('smith')}
           className="group relative flex flex-1 cursor-pointer items-center justify-center border-b-2 border-[#8b4513] bg-gradient-to-br from-[#2c1810] via-[#4a2c1a] to-[#1a1611] text-[#d4953a] transition-all duration-500 hover:flex-[1.2] md:border-b-0 md:border-r-2"
         >
-          <div className="absolute inset-0 overflow-hidden flex items-center justify-center">
-            <div className="title-background text-[4rem] sm:text-[6rem] md:text-[8rem] font-black tracking-widest opacity-10">SMITH</div>
-          </div>
           <div className="section-content relative z-10 mx-auto flex max-w-xs flex-col items-center text-center">
             <div className="relative mb-6 flex flex-col items-center">
               <div className="absolute top-0 left-1/2 -translate-x-1/2 md:-top-12">
@@ -186,9 +183,6 @@ export default function LandingPage({ onSelect }: Props) {
           onClick={() => onSelect('skald')}
           className="group relative flex flex-1 cursor-pointer items-center justify-center border-t-2 border-b-2 border-[#4682b4] bg-gradient-to-br from-[#1a2332] via-[#2d4a6b] to-[#1a1611] text-[#87ceeb] transition-all duration-500 hover:flex-[1.2] md:border-t-0 md:border-b-0 md:border-l-2 md:border-r-2"
         >
-          <div className="absolute inset-0 overflow-hidden flex items-center justify-center">
-            <div className="title-background text-[4rem] sm:text-[6rem] md:text-[8rem] font-black tracking-widest opacity-10">SKALD</div>
-          </div>
           <div className="section-content relative z-10 mx-auto flex max-w-xs flex-col items-center text-center">
             <div className="relative mb-6 flex flex-col items-center">
               <div className="absolute top-0 left-1/2 -translate-x-1/2 md:-top-12">
@@ -225,9 +219,6 @@ export default function LandingPage({ onSelect }: Props) {
           onClick={() => onSelect('warrior')}
           className="group relative flex flex-1 cursor-pointer items-center justify-center border-t-2 border-[#eab308] bg-gradient-to-br from-[#33260f] via-[#5b4a1a] to-[#1a1611] text-[#eab308] transition-all duration-500 hover:flex-[1.2] md:border-t-0 md:border-l-2"
         >
-          <div className="absolute inset-0 overflow-hidden flex items-center justify-center">
-            <div className="title-background text-[4rem] sm:text-[6rem] md:text-[8rem] font-black tracking-widest opacity-10">WARRIOR</div>
-          </div>
           <div className="section-content relative z-10 mx-auto flex max-w-xs flex-col items-center text-center">
             <div className="relative mb-6 flex flex-col items-center">
               <div className="absolute top-0 left-1/2 -translate-x-1/2 md:-top-12">

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -166,16 +166,13 @@ export default function LandingPage({ onSelect }: Props) {
             <p className="section-description mb-6 font-mono text-xs opacity-90 sm:text-sm">
               Wielding modern weapons to conquer digital realms. Building fortresses that stand the test of time.
             </p>
-            <div className="skill-runes mb-8 flex flex-wrap justify-center gap-2">
+            <ul className="rune-list mb-8 text-left">
               {smithRunes.map(r => (
-                <span
-                  key={r}
-                  className="rune-tag rounded border border-current bg-black/30 px-2 py-1 text-xs font-mono sm:text-sm"
-                >
+                <li key={r} className="font-mono text-xs sm:text-sm">
                   {r}
-                </span>
+                </li>
               ))}
-            </div>
+            </ul>
             <div className="action-hint flex items-center justify-center gap-2 text-xs font-mono opacity-70 sm:text-sm">
               <span>Enter the workshop</span>
               <span className="axe-indicator animate-axe">⚔️</span>
@@ -208,16 +205,13 @@ export default function LandingPage({ onSelect }: Props) {
             <p className="section-description mb-6 font-mono text-xs opacity-90 sm:text-sm">
               Crafting sagas that echo through the ages. Words that kindle fire in mortal hearts.
             </p>
-            <div className="story-runes mb-8 flex flex-wrap justify-center gap-2">
+            <ul className="rune-list mb-8 text-left">
               {skaldRunes.map(r => (
-                <span
-                  key={r}
-                  className="rune-tag rounded border border-current bg-black/30 px-2 py-1 text-xs font-mono sm:text-sm"
-                >
+                <li key={r} className="font-mono text-xs sm:text-sm">
                   {r}
-                </span>
+                </li>
               ))}
-            </div>
+            </ul>
             <div className="action-hint flex items-center justify-center gap-2 text-xs font-mono opacity-70 sm:text-sm">
               <span>Enter the hall</span>
               <span className="axe-indicator animate-axe">📜</span>
@@ -250,16 +244,13 @@ export default function LandingPage({ onSelect }: Props) {
             <p className="section-description mb-6 font-mono text-xs opacity-90 sm:text-sm">
               Building strength and discipline through iron and nutrition.
             </p>
-            <div className="story-runes mb-8 flex flex-wrap justify-center gap-2">
+            <ul className="rune-list mb-8 text-left">
               {warriorRunes.map(r => (
-                <span
-                  key={r}
-                  className="rune-tag rounded border border-current bg-black/30 px-2 py-1 text-xs font-mono sm:text-sm"
-                >
+                <li key={r} className="font-mono text-xs sm:text-sm">
                   {r}
-                </span>
+                </li>
               ))}
-            </div>
+            </ul>
             <div className="action-hint flex items-center justify-center gap-2 text-xs font-mono opacity-70 sm:text-sm">
               <span>Enter the training ground</span>
               <span className="axe-indicator animate-axe">🏋️</span>

--- a/src/index.css
+++ b/src/index.css
@@ -50,3 +50,16 @@
     animation: spin-slow 8s linear infinite reverse;
   }
 }
+
+@layer components {
+  .rune-list {
+    @apply space-y-2;
+  }
+  .rune-list li::before {
+    content: 'ᛟ';
+    @apply mr-2 text-base;
+  }
+  .rune-list li {
+    @apply flex items-center;
+  }
+}


### PR DESCRIPTION
## Summary
- Revamp site overlay with updated tagline and subtle divider for a cleaner hero
- Replace tag grids with runic bullet lists for Smith, Skald, and Warrior sections
- Add reusable rune-list component styles to match a cohesive Viking aesthetic

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae3ea5e948832a94b0024087dbfd4e