### PR TITLE
feat: expand warrior page layout

### DIFF
--- a/src/WarriorPage.tsx
+++ b/src/WarriorPage.tsx
@@ -1,19 +1,52 @@
-import React from 'react';
+import warrior from './data/warrior.json';
 
 interface Props {
   onBack: () => void;
 }
 
-const glanceStats = [
-  { title: 'Bodyweight', value: '92.4 kg', note: '▼ 0.6 kg/wk' },
-  { title: 'Body Fat', value: '18–20%', note: 'Target <15%' },
-  { title: 'Weekly Deficit', value: '–4,200 kcal', note: '≈0.5 kg loss' },
-  { title: 'Row 10′', value: '2.3 → 2.5 km', note: '' },
-  { title: 'Pull-ups', value: '8 → 12', note: '' },
-  { title: 'Sleep', value: '7.5 h', note: 'Goal 8 h' },
-];
+type GlanceStat = {
+  title: string;
+  value: string;
+  note?: string;
+};
 
-const icons = {
+type IconName = 'axe' | 'shield' | 'raven';
+
+type PersonalBest = {
+  icon: IconName;
+  title: string;
+  value: string;
+  date: string;
+};
+
+type DietItem = {
+  title: string;
+  content?: string;
+  list?: string[];
+};
+
+type TrainingItem = {
+  day: string;
+  plan: string;
+  cals: string;
+};
+
+type SupplementItem = {
+  title: string;
+  list: string[];
+};
+
+interface WarriorData {
+  glanceStats: GlanceStat[];
+  personalBests: PersonalBest[];
+  diet: DietItem[];
+  training: TrainingItem[];
+  supplements: SupplementItem[];
+}
+
+const data = warrior as WarriorData;
+
+const icons: Record<IconName, JSX.Element> = {
   axe: (
     <svg viewBox="0 0 24 24" className="h-5 w-5">
       <path
@@ -40,62 +73,8 @@ const icons = {
   ),
 };
 
-const personalBests = [
-  { icon: icons.axe, title: 'Deadlift', value: '145 kg × 3', date: '2025-08-23' },
-  { icon: icons.shield, title: 'Barbell Row', value: '105 kg × 6', date: '2025-08-26' },
-  { icon: icons.shield, title: 'Back Squat', value: '100 kg × 6', date: 'Baseline' },
-  { icon: icons.raven, title: 'Clean & Press', value: '55 kg × 5', date: '2025-08-23' },
-  { icon: icons.axe, title: 'Flat DB Press', value: '40 kg × 3', date: '2025-08-23' },
-  { icon: icons.raven, title: 'Row (10:33)', value: '2319 m', date: '~137 W avg' },
-];
-
-const diet = [
-  {
-    title: 'Macros',
-    content: '~2,535 kcal/day\nProtein 226 g · Fat 100 g · Carbs 187 g',
-  },
-  {
-    title: 'Meals',
-    list: [
-      '3 eggs, 3× toast, spread, spinach, cottage cheese',
-      '3 eggs, 2× toast, spread, spinach, cottage cheese',
-      '2× whey shakes + yogurt',
-      '2 chicken legs + 60g rice + veg',
-    ],
-  },
-  {
-    title: 'Rules',
-    list: ['No snacks', 'Monster Ultra ≤2 before 17:00', '≥2L water daily'],
-  },
-];
-
-const training = [
-  { day: 'Mon — Chest', plan: 'Bench GVT + Flys', cals: '~632 kcal' },
-  { day: 'Tue — Back', plan: 'Pull-ups · Rows · Pulldown', cals: '~665–700 kcal' },
-  { day: 'Wed — Shoulders', plan: 'Press · Laterals · Upright Rows', cals: '~641 kcal' },
-  { day: 'Thu — Legs', plan: 'Squat · RDL · Lunges', cals: '~701 kcal' },
-  { day: 'Fri — Arms', plan: 'Bicep/Tricep GVT', cals: '~940 kcal' },
-  { day: 'Sat — Pump', plan: 'Chest/Shoulder pump', cals: '~696 kcal' },
-  { day: 'Sun — Recovery', plan: 'Fast walk + sleep focus', cals: '~413 kcal' },
-];
-
-const supplements = [
-  {
-    title: 'Morning Stack',
-    list: [
-      'AREDS2 · Omega-3 · D3',
-      'Ginseng · Lion’s Mane · B12',
-      'Shilajit · Maca · Creatine',
-      'Pump/Beetroot (training/rest)',
-    ],
-  },
-  {
-    title: 'Evening Stack',
-    list: ['Magnesium Glycinate', 'Ashwagandha', 'Omega-3 (optional split)'],
-  },
-];
-
 export default function WarriorPage({ onBack }: Props) {
+  const { glanceStats, personalBests, diet, training, supplements } = data;
   return (
     <div className="min-h-screen bg-[#0b0a08] text-[#f4e8bd]">
       <button
@@ -171,7 +150,7 @@ export default function WarriorPage({ onBack }: Props) {
                 className="relative rounded-lg border border-[#463720] bg-[#13100d] p-4 shadow hover:border-[#eab308] transition"
               >
                 <div className="mb-2 flex items-center justify-center gap-2 text-[#eab308]">
-                  {pb.icon}
+                  {icons[pb.icon]}
                   <div className="text-sm font-semibold tracking-widest">{pb.title}</div>
                 </div>
                 <div className="text-center text-2xl font-bold text-[#ffde8a]">{pb.value}</div>

--- a/src/WarriorPage.tsx
+++ b/src/WarriorPage.tsx
@@ -4,30 +4,247 @@ interface Props {
   onBack: () => void;
 }
 
+const glanceStats = [
+  { title: 'Bodyweight', value: '92.4 kg', note: '▼ 0.6 kg/wk' },
+  { title: 'Body Fat', value: '18–20%', note: 'Target <15%' },
+  { title: 'Weekly Deficit', value: '–4,200 kcal', note: '≈0.5 kg loss' },
+  { title: 'Row 10′', value: '2.3 → 2.5 km', note: '' },
+  { title: 'Pull-ups', value: '8 → 12', note: '' },
+  { title: 'Sleep', value: '7.5 h', note: 'Goal 8 h' },
+];
+
+const icons = {
+  axe: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5">
+      <path
+        fill="currentColor"
+        d="M2 22l7-7 2 2-7 7H2zm11-11l-2-2 6-6 2 2-1.8 1.8 2.2 2.2-2 2-2.2-2.2L13 11z"
+      />
+    </svg>
+  ),
+  shield: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5">
+      <path
+        fill="currentColor"
+        d="M12 2l8 3v6c0 5-3.5 9.6-8 11-4.5-1.4-8-6-8-11V5l8-3z"
+      />
+    </svg>
+  ),
+  raven: (
+    <svg viewBox="0 0 24 24" className="h-5 w-5">
+      <path
+        fill="currentColor"
+        d="M3 12l8-2 10-6-6 8 6 6-8-3-6 5 2-7z"
+      />
+    </svg>
+  ),
+};
+
+const personalBests = [
+  { icon: icons.axe, title: 'Deadlift', value: '145 kg × 3', date: '2025-08-23' },
+  { icon: icons.shield, title: 'Barbell Row', value: '105 kg × 6', date: '2025-08-26' },
+  { icon: icons.shield, title: 'Back Squat', value: '100 kg × 6', date: 'Baseline' },
+  { icon: icons.raven, title: 'Clean & Press', value: '55 kg × 5', date: '2025-08-23' },
+  { icon: icons.axe, title: 'Flat DB Press', value: '40 kg × 3', date: '2025-08-23' },
+  { icon: icons.raven, title: 'Row (10:33)', value: '2319 m', date: '~137 W avg' },
+];
+
+const diet = [
+  {
+    title: 'Macros',
+    content: '~2,535 kcal/day\nProtein 226 g · Fat 100 g · Carbs 187 g',
+  },
+  {
+    title: 'Meals',
+    list: [
+      '3 eggs, 3× toast, spread, spinach, cottage cheese',
+      '3 eggs, 2× toast, spread, spinach, cottage cheese',
+      '2× whey shakes + yogurt',
+      '2 chicken legs + 60g rice + veg',
+    ],
+  },
+  {
+    title: 'Rules',
+    list: ['No snacks', 'Monster Ultra ≤2 before 17:00', '≥2L water daily'],
+  },
+];
+
+const training = [
+  { day: 'Mon — Chest', plan: 'Bench GVT + Flys', cals: '~632 kcal' },
+  { day: 'Tue — Back', plan: 'Pull-ups · Rows · Pulldown', cals: '~665–700 kcal' },
+  { day: 'Wed — Shoulders', plan: 'Press · Laterals · Upright Rows', cals: '~641 kcal' },
+  { day: 'Thu — Legs', plan: 'Squat · RDL · Lunges', cals: '~701 kcal' },
+  { day: 'Fri — Arms', plan: 'Bicep/Tricep GVT', cals: '~940 kcal' },
+  { day: 'Sat — Pump', plan: 'Chest/Shoulder pump', cals: '~696 kcal' },
+  { day: 'Sun — Recovery', plan: 'Fast walk + sleep focus', cals: '~413 kcal' },
+];
+
+const supplements = [
+  {
+    title: 'Morning Stack',
+    list: [
+      'AREDS2 · Omega-3 · D3',
+      'Ginseng · Lion’s Mane · B12',
+      'Shilajit · Maca · Creatine',
+      'Pump/Beetroot (training/rest)',
+    ],
+  },
+  {
+    title: 'Evening Stack',
+    list: ['Magnesium Glycinate', 'Ashwagandha', 'Omega-3 (optional split)'],
+  },
+];
+
 export default function WarriorPage({ onBack }: Props) {
   return (
-    <div className="min-h-screen bg-[#1a1611] p-4 text-[#eab308] md:p-8">
+    <div className="min-h-screen bg-[#0b0a08] text-[#f4e8bd]">
       <button
         onClick={onBack}
-        className="fixed top-4 left-4 rounded border-2 border-[#eab308] bg-black/80 px-4 py-2 transition hover:bg-[#eab308] hover:text-[#1a1611] md:top-8 md:left-8 md:px-6 md:py-3"
+        className="fixed top-4 left-4 rounded border-2 border-[#eab308] bg-black/60 px-4 py-2 text-sm transition hover:bg-[#eab308] hover:text-black md:top-8 md:left-8 md:px-6 md:py-3"
       >
         ← Return to Longhouse
       </button>
 
-      <div className="mx-auto mt-20 max-w-3xl text-center space-y-6 md:mt-24 md:space-y-8">
-        <h1 className="text-4xl md:text-5xl font-bold">WARRIOR</h1>
-        <p className="text-lg opacity-90">
-          Chronicles of strength and nutrition. Follow the full journey in the{' '}
-          <a
-            href="https://github.com/itsjonjoe/fitness-docs"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            fitness docs
+      <div className="mx-auto max-w-6xl p-4 pt-20 space-y-10 md:pt-24">
+        {/* Hero */}
+        <header className="relative overflow-hidden rounded-2xl border-2 border-[#eab308] bg-[#13100d] text-center shadow-lg">
+          <div className="p-10 sm:p-12">
+            <h1 className="bg-gradient-to-b from-yellow-200 to-yellow-600 bg-clip-text text-5xl font-bold tracking-wide text-transparent sm:text-6xl md:text-7xl">
+              WARRIOR
+            </h1>
+            <p className="mt-2 text-sm text-[#c7b98a] sm:text-base">
+              Chronicle of strength and endurance · Project Viking
+            </p>
+          </div>
+        </header>
+
+        {/* Subnav */}
+        <nav className="flex flex-wrap justify-center gap-2 text-sm" aria-label="Section navigation">
+          <a href="#glance" className="rounded-full border border-[#3a2f20] px-4 py-2 text-[#c7b98a] transition hover:border-[#eab308] hover:text-[#f4e8bd]">
+            At a Glance
           </a>
-          .
-        </p>
+          <a href="#pbs" className="rounded-full border border-[#3a2f20] px-4 py-2 text-[#c7b98a] transition hover:border-[#eab308] hover:text-[#f4e8bd]">
+            Personal Bests
+          </a>
+          <a href="#diet" className="rounded-full border border-[#3a2f20] px-4 py-2 text-[#c7b98a] transition hover:border-[#eab308] hover:text-[#f4e8bd]">
+            Diet
+          </a>
+          <a href="#training" className="rounded-full border border-[#3a2f20] px-4 py-2 text-[#c7b98a] transition hover:border-[#eab308] hover:text-[#f4e8bd]">
+            Training
+          </a>
+          <a href="#supps" className="rounded-full border border-[#3a2f20] px-4 py-2 text-[#c7b98a] transition hover:border-[#eab308] hover:text-[#f4e8bd]">
+            Supplements
+          </a>
+        </nav>
+
+        {/* At a Glance */}
+        <section id="glance" className="space-y-6">
+          <h2 className="text-center text-2xl font-semibold tracking-widest text-[#eab308]">At a Glance</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {glanceStats.map((s) => (
+              <div
+                key={s.title}
+                className="rounded-lg border border-[#463720] bg-[#13100d] p-4 text-center shadow hover:border-[#eab308] transition"
+              >
+                <h3 className="font-semibold tracking-wide text-[#eab308]">{s.title}</h3>
+                <p className="mt-2 text-sm text-[#c7b98a]">
+                  {s.value}
+                  {s.note && (
+                    <>
+                      <br />
+                      <em>{s.note}</em>
+                    </>
+                  )}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Personal Bests */}
+        <section id="pbs" className="space-y-6">
+          <h2 className="text-center text-2xl font-semibold tracking-widest text-[#eab308]">Personal Bests</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {personalBests.map((pb) => (
+              <div
+                key={pb.title}
+                className="relative rounded-lg border border-[#463720] bg-[#13100d] p-4 shadow hover:border-[#eab308] transition"
+              >
+                <div className="mb-2 flex items-center justify-center gap-2 text-[#eab308]">
+                  {pb.icon}
+                  <div className="text-sm font-semibold tracking-widest">{pb.title}</div>
+                </div>
+                <div className="text-center text-2xl font-bold text-[#ffde8a]">{pb.value}</div>
+                <div className="mt-1 text-center text-xs text-[#c7b98a]">{pb.date}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Diet */}
+        <section id="diet" className="space-y-6">
+          <h2 className="text-center text-2xl font-semibold tracking-widest text-[#eab308]">Diet</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {diet.map((d) => (
+              <div
+                key={d.title}
+                className="rounded-lg border border-[#463720] bg-[#13100d] p-4 shadow hover:border-[#eab308] transition"
+              >
+                <h3 className="font-semibold tracking-wide text-[#eab308]">{d.title}</h3>
+                {d.content && (
+                  <p className="mt-2 text-sm text-[#c7b98a] whitespace-pre-line">{d.content}</p>
+                )}
+                {d.list && (
+                  <ul className="mt-2 list-disc list-inside text-sm text-[#c7b98a]">
+                    {d.list.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Training */}
+        <section id="training" className="space-y-6">
+          <h2 className="text-center text-2xl font-semibold tracking-widest text-[#eab308]">Training Block</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {training.map((t) => (
+              <div
+                key={t.day}
+                className="rounded-lg border border-[#463720] bg-[#13100d] p-4 shadow hover:border-[#eab308] transition"
+              >
+                <h3 className="font-semibold tracking-wide text-[#eab308]">{t.day}</h3>
+                <p className="mt-2 text-sm text-[#c7b98a]">
+                  {t.plan}
+                  <br />
+                  <em>{t.cals}</em>
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Supplements */}
+        <section id="supps" className="space-y-6 pb-12">
+          <h2 className="text-center text-2xl font-semibold tracking-widest text-[#eab308]">Supplements</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {supplements.map((s) => (
+              <div
+                key={s.title}
+                className="rounded-lg border border-[#463720] bg-[#13100d] p-4 shadow hover:border-[#eab308] transition"
+              >
+                <h3 className="font-semibold tracking-wide text-[#eab308]">{s.title}</h3>
+                <ul className="mt-2 list-disc list-inside text-sm text-[#c7b98a]">
+                  {s.list.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/src/data/warrior.json
+++ b/src/data/warrior.json
@@ -1,0 +1,54 @@
+{
+  "glanceStats": [
+    { "title": "Bodyweight", "value": "92.4 kg", "note": "\u25BC 0.6 kg/wk" },
+    { "title": "Body Fat", "value": "18\u201320%", "note": "Target <15%" },
+    { "title": "Weekly Deficit", "value": "\u20134,200 kcal", "note": "\u22480.5 kg loss" },
+    { "title": "Row 10\u2032", "value": "2.3 \u2192 2.5 km" },
+    { "title": "Pull-ups", "value": "8 \u2192 12" },
+    { "title": "Sleep", "value": "7.5 h", "note": "Goal 8 h" }
+  ],
+  "personalBests": [
+    { "icon": "axe", "title": "Deadlift", "value": "145 kg \u00D7 3", "date": "2025-08-23" },
+    { "icon": "shield", "title": "Barbell Row", "value": "105 kg \u00D7 6", "date": "2025-08-26" },
+    { "icon": "shield", "title": "Back Squat", "value": "100 kg \u00D7 6", "date": "Baseline" },
+    { "icon": "raven", "title": "Clean & Press", "value": "55 kg \u00D7 5", "date": "2025-08-23" },
+    { "icon": "axe", "title": "Flat DB Press", "value": "40 kg \u00D7 3", "date": "2025-08-23" },
+    { "icon": "raven", "title": "Row (10:33)", "value": "2319 m", "date": "~137 W avg" }
+  ],
+  "diet": [
+    { "title": "Macros", "content": "~2,535 kcal/day\nProtein 226 g \u00B7 Fat 100 g \u00B7 Carbs 187 g" },
+    { "title": "Meals", "list": [
+        "3 eggs, 3\u00D7 toast, spread, spinach, cottage cheese",
+        "3 eggs, 2\u00D7 toast, spread, spinach, cottage cheese",
+        "2\u00D7 whey shakes + yogurt",
+        "2 chicken legs + 60g rice + veg"
+    ]},
+    { "title": "Rules", "list": [
+        "No snacks",
+        "Monster Ultra \u22642 before 17:00",
+        "\u22652L water daily"
+    ]}
+  ],
+  "training": [
+    { "day": "Mon \u2014 Chest", "plan": "Bench GVT + Flys", "cals": "~632 kcal" },
+    { "day": "Tue \u2014 Back", "plan": "Pull-ups \u00B7 Rows \u00B7 Pulldown", "cals": "~665\u2013700 kcal" },
+    { "day": "Wed \u2014 Shoulders", "plan": "Press \u00B7 Laterals \u00B7 Upright Rows", "cals": "~641 kcal" },
+    { "day": "Thu \u2014 Legs", "plan": "Squat \u00B7 RDL \u00B7 Lunges", "cals": "~701 kcal" },
+    { "day": "Fri \u2014 Arms", "plan": "Bicep/Tricep GVT", "cals": "~940 kcal" },
+    { "day": "Sat \u2014 Pump", "plan": "Chest/Shoulder pump", "cals": "~696 kcal" },
+    { "day": "Sun \u2014 Recovery", "plan": "Fast walk + sleep focus", "cals": "~413 kcal" }
+  ],
+  "supplements": [
+    { "title": "Morning Stack", "list": [
+        "AREDS2 \u00B7 Omega-3 \u00B7 D3",
+        "Ginseng \u00B7 Lion’s Mane \u00B7 B12",
+        "Shilajit \u00B7 Maca \u00B7 Creatine",
+        "Pump/Beetroot (training/rest)"
+    ]},
+    { "title": "Evening Stack", "list": [
+        "Magnesium Glycinate",
+        "Ashwagandha",
+        "Omega-3 (optional split)"
+    ]}
+  ]
+}


### PR DESCRIPTION
## Summary
- replace placeholder warrior page with polished, responsive layout
- add stat, personal best, diet, training, and supplement sections with data-driven cards

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae3f454858832a8c5c70bd890508a7