### PR TITLE
Add React Router for page navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import LandingPage from './LandingPage';
 import WarriorPage from './WarriorPage';
 import SkaldPage from './SkaldPage';
@@ -13,32 +13,20 @@ const SiteOverlay = () => (
   </div>
 );
 
-export type Page = 'landing' | 'smith' | 'skald' | 'warrior';
-
-const App = () => {
-  const [page, setPage] = useState<Page>('landing');
-
-  let content: JSX.Element;
-  switch (page) {
-    case 'smith':
-      content = <SmithPage onBack={() => setPage('landing')} />;
-      break;
-    case 'skald':
-      content = <SkaldPage onBack={() => setPage('landing')} />;
-      break;
-    case 'warrior':
-      content = <WarriorPage onBack={() => setPage('landing')} />;
-      break;
-    default:
-      content = <LandingPage onSelect={setPage} />;
-  }
-
-  return (
+const App = () => (
+  <Router>
     <div className="relative">
       <SiteOverlay />
-      <div className="relative z-10">{content}</div>
+      <div className="relative z-10">
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/engineering" element={<SmithPage />} />
+          <Route path="/writing" element={<SkaldPage />} />
+          <Route path="/warrior" element={<WarriorPage />} />
+        </Routes>
+      </div>
     </div>
-  );
-};
+  </Router>
+);
 
 export default App;

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Page } from './App';
-
-interface Props {
-  onSelect: (p: Page) => void;
-}
+import { useNavigate } from 'react-router-dom';
 
 const smithTexts = ['Code Forger', 'System Builder', 'Tech Viking', 'Digital Warrior'];
 const skaldTexts = ['Tale Weaver', 'Word Smith', 'Story Teller', 'Saga Writer'];
@@ -104,7 +100,8 @@ const VikingCrest = ({ className = '' }: { className?: string }) => (
   </div>
 );
 
-export default function LandingPage({ onSelect }: Props) {
+export default function LandingPage() {
+  const navigate = useNavigate();
   const [smithIndex, setSmithIndex] = useState(0);
   const [skaldIndex, setSkaldIndex] = useState(0);
   const [warriorIndex, setWarriorIndex] = useState(0);
@@ -143,7 +140,7 @@ export default function LandingPage({ onSelect }: Props) {
       <div className="landing-page relative flex h-screen flex-col md:flex-row">
         {/* Smith Section */}
         <section
-          onClick={() => onSelect('smith')}
+          onClick={() => navigate('/engineering')}
           className="group relative flex flex-1 cursor-pointer items-center justify-center border-b-2 border-[#8b4513] bg-gradient-to-br from-[#2c1810] via-[#4a2c1a] to-[#1a1611] text-[#d4953a] transition-all duration-500 hover:flex-[1.2] md:border-b-0 md:border-r-2"
         >
           <div className="absolute inset-0 overflow-hidden flex items-center justify-center">
@@ -186,7 +183,7 @@ export default function LandingPage({ onSelect }: Props) {
 
         {/* Skald Section */}
         <section
-          onClick={() => onSelect('skald')}
+          onClick={() => navigate('/writing')}
           className="group relative flex flex-1 cursor-pointer items-center justify-center border-t-2 border-b-2 border-[#4682b4] bg-gradient-to-br from-[#1a2332] via-[#2d4a6b] to-[#1a1611] text-[#87ceeb] transition-all duration-500 hover:flex-[1.2] md:border-t-0 md:border-b-0 md:border-l-2 md:border-r-2"
         >
           <div className="absolute inset-0 overflow-hidden flex items-center justify-center">
@@ -228,7 +225,7 @@ export default function LandingPage({ onSelect }: Props) {
 
         {/* Warrior Section */}
         <section
-          onClick={() => onSelect('warrior')}
+          onClick={() => navigate('/warrior')}
           className="group relative flex flex-1 cursor-pointer items-center justify-center border-t-2 border-[#eab308] bg-gradient-to-br from-[#33260f] via-[#5b4a1a] to-[#1a1611] text-[#eab308] transition-all duration-500 hover:flex-[1.2] md:border-t-0 md:border-l-2"
         >
           <div className="absolute inset-0 overflow-hidden flex items-center justify-center">

--- a/src/SkaldPage.tsx
+++ b/src/SkaldPage.tsx
@@ -1,12 +1,11 @@
-interface Props {
-  onBack: () => void;
-}
+import { useNavigate } from 'react-router-dom';
 
-export default function SkaldPage({ onBack }: Props) {
+export default function SkaldPage() {
+  const navigate = useNavigate();
   return (
     <div className="min-h-screen bg-[#1a1611] p-4 text-[#87ceeb] md:p-8">
       <button
-        onClick={onBack}
+        onClick={() => navigate('/')}
         className="fixed top-4 left-4 rounded border-2 border-[#4682b4] bg-black/80 px-4 py-2 transition hover:bg-[#4682b4] hover:text-white md:top-8 md:left-8 md:px-6 md:py-3"
       >
         ← Return to Longhouse

--- a/src/SmithPage.tsx
+++ b/src/SmithPage.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-
-interface Props {
-  onBack: () => void;
-}
+import { useNavigate } from 'react-router-dom';
 
 const stats = [
   { value: '10+', label: 'Years of Experience' },
@@ -96,11 +93,12 @@ const testimonials = [
   },
 ];
 
-export default function SmithPage({ onBack }: Props) {
+export default function SmithPage() {
+  const navigate = useNavigate();
   return (
     <div className="min-h-screen bg-[#1a1611] p-4 text-[#d4953a] md:p-8">
       <button
-        onClick={onBack}
+        onClick={() => navigate('/')}
         className="fixed top-4 left-4 rounded border-2 border-[#8b4513] bg-black/80 px-4 py-2 transition hover:bg-[#8b4513] hover:text-white md:top-8 md:left-8 md:px-6 md:py-3"
       >
         ← Return to Longhouse

--- a/src/WarriorPage.tsx
+++ b/src/WarriorPage.tsx
@@ -1,8 +1,5 @@
 import warrior from './data/warrior.json';
-
-interface Props {
-  onBack: () => void;
-}
+import { useNavigate } from 'react-router-dom';
 
 type GlanceStat = {
   title: string;
@@ -73,12 +70,13 @@ const icons: Record<IconName, JSX.Element> = {
   ),
 };
 
-export default function WarriorPage({ onBack }: Props) {
+export default function WarriorPage() {
+  const navigate = useNavigate();
   const { glanceStats, personalBests, diet, training, supplements } = data;
   return (
     <div className="min-h-screen bg-[#0b0a08] text-[#f4e8bd]">
       <button
-        onClick={onBack}
+        onClick={() => navigate('/')}
         className="fixed top-4 left-4 rounded border-2 border-[#eab308] bg-black/60 px-4 py-2 text-sm transition hover:bg-[#eab308] hover:text-black md:top-8 md:left-8 md:px-6 md:py-3"
       >
         ← Return to Longhouse


### PR DESCRIPTION
## Summary
- Set up React Router with routes for landing, engineering, writing, and warrior pages
- Use `useNavigate` for in-app navigation and back buttons
- Add `react-router-dom` dependency

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68ae45ab77cc832ab45f39db75e64ffc