### PR TITLE
Show ghost overlay only on home page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
 import LandingPage from './LandingPage';
 import WarriorPage from './WarriorPage';
 import SkaldPage from './SkaldPage';
@@ -12,11 +12,12 @@ const SiteOverlay = () => (
   </div>
 );
 
-const App = () => (
-  <Router>
+const AppRoutes = () => {
+  const location = useLocation();
+  return (
     <div className="relative">
-      <SiteOverlay />
-      
+      {location.pathname === '/' && <SiteOverlay />}
+
       <div className="relative z-10">
         <Routes>
           <Route path="/" element={<LandingPage />} />
@@ -26,6 +27,12 @@ const App = () => (
         </Routes>
       </div>
     </div>
+  );
+};
+
+const App = () => (
+  <Router>
+    <AppRoutes />
   </Router>
 );
 


### PR DESCRIPTION
## Summary
- Render site overlay on home route only using `useLocation`.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68ae47f1aaa0832ab929c191803b10a7